### PR TITLE
feat(property): implementa upload de fotos no cadastro de imóveis

### DIFF
--- a/backend/src/main/java/br/edu/ufape/roomie/controller/PropertyController.java
+++ b/backend/src/main/java/br/edu/ufape/roomie/controller/PropertyController.java
@@ -2,16 +2,18 @@ package br.edu.ufape.roomie.controller;
 
 import br.edu.ufape.roomie.dto.PropertyRequestDTO;
 import br.edu.ufape.roomie.model.Property;
-import br.edu.ufape.roomie.model.User;
 import br.edu.ufape.roomie.service.PropertyService;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/properties")
@@ -23,9 +25,12 @@ public class PropertyController {
         this.propertyService = propertyService;
     }
 
-    @PostMapping
-    public ResponseEntity<Property> store(@RequestBody PropertyRequestDTO dto) {
-        Property createdProperty = propertyService.createProperty(dto);
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Property> store(
+            @Valid @RequestPart("data") PropertyRequestDTO dto,
+            @RequestPart(value = "photos", required = false) List<MultipartFile> photos
+    ) {
+        Property createdProperty = propertyService.createProperty(dto, photos);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdProperty);
     }
 }

--- a/backend/src/main/java/br/edu/ufape/roomie/model/Property.java
+++ b/backend/src/main/java/br/edu/ufape/roomie/model/Property.java
@@ -7,6 +7,9 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "Imovel")
 @Data
@@ -49,4 +52,7 @@ public class Property {
 
     @OneToOne(mappedBy = "property", cascade = CascadeType.ALL)
     private Address address;
+
+    @OneToMany(mappedBy = "property", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PropertyPhoto> photos = new ArrayList<>();
 }

--- a/backend/src/main/java/br/edu/ufape/roomie/model/PropertyPhoto.java
+++ b/backend/src/main/java/br/edu/ufape/roomie/model/PropertyPhoto.java
@@ -1,0 +1,23 @@
+package br.edu.ufape.roomie.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "Imagem_Imovel")
+@Data
+@NoArgsConstructor
+public class PropertyPhoto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_imagem")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "id_imovel", nullable = false)
+    private Property property;
+
+    @Column(nullable = false, name = "caminho_imagem")
+    private String path;
+}

--- a/backend/src/main/java/br/edu/ufape/roomie/service/FileStorageService.java
+++ b/backend/src/main/java/br/edu/ufape/roomie/service/FileStorageService.java
@@ -1,0 +1,57 @@
+package br.edu.ufape.roomie.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Service
+public class FileStorageService {
+
+    private final Path fileStorageLocation;
+
+    public FileStorageService(@Value("${app.storage.upload-dir:uploads/imoveis}") String uploadDir) {
+        this.fileStorageLocation = Paths.get(uploadDir).toAbsolutePath().normalize();
+
+        try {
+            Files.createDirectories(this.fileStorageLocation);
+        } catch (Exception ex) {
+            throw new RuntimeException("Não foi possível criar o diretório onde os arquivos serão armazenados.", ex);
+        }
+    }
+
+    public String storeFile(MultipartFile file) {
+        // Pega o nome original do arquivo e limpa o caminho
+        String originalFileName = StringUtils.cleanPath(file.getOriginalFilename());
+
+        try {
+            // Verifica se o nome do arquivo contém caracteres inválidos
+            if (originalFileName.contains("..")) {
+                throw new RuntimeException("Desculpe! O nome do arquivo contém um caminho inválido " + originalFileName);
+            }
+
+            // Gera um nome único usando UUID para evitar sobrescrever imagens com o mesmo nome (ex: foto.jpg)
+            String fileExtension = originalFileName.substring(originalFileName.lastIndexOf("."));
+            String newFileName = UUID.randomUUID().toString() + fileExtension;
+
+            // Resolve o caminho final onde o arquivo será salvo
+            Path targetLocation = this.fileStorageLocation.resolve(newFileName);
+
+            // Copia o arquivo para o diretório alvo (Substituindo se já existir)
+            Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+
+            // Retorna o nome do arquivo gerado para salvarmos no banco de dados
+            return newFileName;
+
+        } catch (IOException ex) {
+            throw new RuntimeException("Não foi possível armazenar o arquivo " + originalFileName + ". Por favor, tente novamente!", ex);
+        }
+    }
+}

--- a/backend/src/main/java/br/edu/ufape/roomie/service/PropertyService.java
+++ b/backend/src/main/java/br/edu/ufape/roomie/service/PropertyService.java
@@ -4,6 +4,7 @@ import br.edu.ufape.roomie.dto.PropertyRequestDTO;
 import br.edu.ufape.roomie.enums.PropertyStatus;
 import br.edu.ufape.roomie.model.Address;
 import br.edu.ufape.roomie.model.Property;
+import br.edu.ufape.roomie.model.PropertyPhoto;
 import br.edu.ufape.roomie.model.User;
 import br.edu.ufape.roomie.repository.PropertyRepository;
 import org.springframework.http.HttpStatus;
@@ -11,19 +12,25 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 public class PropertyService {
 
     private final PropertyRepository propertyRepository;
+    private final FileStorageService fileStorageService;
 
-    public PropertyService(PropertyRepository propertyRepository) {
+    public PropertyService(PropertyRepository propertyRepository, FileStorageService fileStorageService) {
         this.propertyRepository = propertyRepository;
+        this.fileStorageService = fileStorageService;
     }
 
     @Transactional
-    public Property createProperty(PropertyRequestDTO dto) {
+    public Property createProperty(PropertyRequestDTO dto, List<MultipartFile> photos) {
         User owner = this.getAuthenticatedUser();
 
         Property property = new Property();
@@ -47,6 +54,20 @@ public class PropertyService {
 
         address.setProperty(property);
         property.setAddress(address);
+
+        List<PropertyPhoto> propertyPhotos = new ArrayList<>();
+        if (photos != null && !photos.isEmpty()) {
+            for (MultipartFile photo : photos) {
+                String fileName = fileStorageService.storeFile(photo);
+
+                PropertyPhoto propertyPhoto = new PropertyPhoto();
+                propertyPhoto.setPath("/images/" + fileName);
+                propertyPhoto.setProperty(property);
+
+                propertyPhotos.add(propertyPhoto);
+            }
+        }
+        property.setPhotos(propertyPhotos);
 
         return propertyRepository.save(property);
     }


### PR DESCRIPTION
- Adiciona a entidade `PropertyPhoto` e a relação @OneToMany na entidade `Property`.
- Cria o `FileStorageService` para gerenciar o armazenamento físico de arquivos localmente com geração de UUID.
- Atualiza o `PropertyController` para consumir requisições `multipart/form-data` utilizando `@RequestPart`.
- Adapta o `PropertyService` para iterar, salvar os arquivos e vincular os caminhos gerados ao imóvel antes da persistência.
- Ajusta o `PropertyControllerTest` e o `PropertyServiceTest` para simular requisições multipart e validar o processamento e mockamento de imagens (`MockMultipartFile`).